### PR TITLE
Add support for overlayfs and cleanup code for future storage drivers

### DIFF
--- a/com_redhat_docker/ks/docker.py
+++ b/com_redhat_docker/ks/docker.py
@@ -199,6 +199,8 @@ class DockerData(AddonData):
         :param instClass: Anaconda installclass object
         """
         # This gets called after entering progress hub, just before installation and device partitioning.
+        if not self.enabled:
+            return
 
         if "docker" not in ksdata.packages.packageList:
             raise KickstartValueError(formatErrorMsg(0, msg=_("%%package section is missing docker")))
@@ -251,6 +253,9 @@ class DockerData(AddonData):
         :param instClass: Anaconda installclass object
         :param users: Anaconda users object
         """
+        if not self.enabled:
+            return
+
         log.info("Executing docker addon")
         # This gets called after installation, before initramfs regeneration and kickstart %post scripts.
         execWithRedirect("mount", ["-o", "bind", getSysroot()+"/var/lib/docker", "/var/lib/docker"])

--- a/docs/docker-anaconda-addon.rst
+++ b/docs/docker-anaconda-addon.rst
@@ -22,7 +22,12 @@ should stop any running containers before the end of the section.
 Storage
 ~~~~~~~
 
-The kickstart needs to setup a LVM thin-pool named 'docker-pool', the VG used
+There are 2 options for storage, LVM thin-pool and OverlayFS. OverlayFS is
+simpler, using the host filesystem from ``/var/lib/docker/`` but it doesn't
+support selinux inside the containers. Pass ``--overlay`` to the addon to
+enable it.
+
+The other option is a LVM thin-pool named 'docker-pool', the VG used
 can be anything, but the VG name needs to be passed to the addon with the
 ``--vgname`` argument. The storage setup will be verified and then the docker
 daemon will be started.
@@ -36,11 +41,17 @@ eg.::
 Addon Section
 ~~~~~~~~~~~~~
 
-The addon command takes 2 required arguments: ``--vgname=VGNAME`` to specify
-the name of the VG containing a LV thin-pool named docker-pool. And
+The addon command arguments depend on whether you are using OverlayFS or LVM.
+OverlayFS is simply ``--overlay``, which will also remove ``--selinux-enabled``
+from the ``/etc/sysconfig/docker`` OPTIONS variable if it is present because
+the overlay doesn't support selinux inside the containers.
+
+When using LVM it requires ``--vgname=VGNAME`` to specify the name of the VG
+containing a LV thin-pool named docker-pool. Optionally you can add
 ``--fstype=FSNAME`` to specify the filesystem type to use with the pool. eg.
-xfs, ext4. You can pass any other arguments to the docker daemon command by adding them to the end
-of the addon command, after ``--``, like this::
+xfs, ext4. The default is xfs. You can pass any other arguments to the docker
+daemon command by adding them to the end of the addon command, after ``--``,
+like this::
 
     %addon com_redhat_docker --vgname=docker --fstype=xfs -- --add-registry docker.foo.bar
 


### PR DESCRIPTION
This cleans up the code a bit so that storage driver specific details
and actions are self-contained in their own classes.

It adds support for --overlay to use the overlayfs driver. A quirk of
this is that selinux isn't supported inside the container when using
overlayfs. The OPTION flag will be edited to remove --selinux-enabled if
it is present.
