### PR TITLE
Fix broken rawhide builds because of docker-utils requires

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ PKGNAME=docker-anaconda-addon
 ADDONNAME=com_redhat_docker
 VERSION=$(shell awk '/Version:/ { print $$2 }' $(PKGNAME).spec)
 ADDONDIR=/usr/share/anaconda/addons/
+PYTHONPATH=.
 
 ZANATA_PULL_ARGS = --transdir po/
 ZANATA_PUSH_ARGS = --srcdir po/ --push-type source --force
 
 check:
 	@echo "*** Running pylint to verify source ***"
-	PYTHONPATH=. tests/pylint/runpylint.py
+	tests/pylint/runpylint.py
 
 clean:
 	-rm pylint-log updates.img

--- a/docker-anaconda-addon.spec
+++ b/docker-anaconda-addon.spec
@@ -18,7 +18,6 @@ BuildRequires: gettext
 Requires: anaconda-core >= 25.5
 Requires: docker
 Requires: docker-selinux
-Requires: docker-utils
 
 %description
 Add a kickstart addon section to Anaconda, com_redhat_docker, to run Docker on


### PR DESCRIPTION
First commit is for better handling with make check.
The second commit should fix rawhide builds which are now broken. I don't know exactly structure of this addon but from my point of view, it looks like docker-utils package has only 2 binary files and they are not used in this addon.

If I am wrong feel free to change the commit as you need.
